### PR TITLE
clean up 'no work...' output

### DIFF
--- a/bfm_seedminer_autolauncher.py
+++ b/bfm_seedminer_autolauncher.py
@@ -98,8 +98,8 @@ def download_file(url, local_filename):
 def getmax(lfcs):
 	lfcs_list=[]
 	isnew=lfcs>>32
-	lfcs&=0xFFFFFF00
-	lfcs|=0x80
+	lfcs&=0xFFFFFFF0
+	lfcs|=0x8
 	c=0
 	if isnew==2:
 		print("new3ds detected")

--- a/bfm_seedminer_autolauncher.py
+++ b/bfm_seedminer_autolauncher.py
@@ -104,14 +104,14 @@ def getmax(lfcs):
 	c=0
 	if isnew==2:
 		print("new3ds detected")
-		max     =[     16,     16,     20,     21,     22,     23,     26,     27,     29,     30,     31,     34,     35,    400]
-		distance=[0x00000,0x00100,0x00200,0x00400,0x00500,0x00600,0x00700,0x00900,0x00A00,0x00B00,0x01000,0x01200,0x02400,0x03F00]
+		max     =[     16,     16,     20]
+		distance=[0x00000,0x00100,0x00200]
 		with open("saves/new-v2.dat", "rb") as f:
 			buf = f.read()
 	elif isnew==0:
 		print("old3ds detected")
-		max     =[     18,     18,     21,     27,     29,     30,     39,     45,     56,    400]
-		distance=[0x00000,0x00100,0x00200,0x00400,0x00600,0x00C00,0x00E00,0x02100,0x06100,0x06200]
+		max     =[     18,     18,     20]
+		distance=[0x00000,0x00100,0x00200]
 		with open("saves/old-v2.dat", "rb") as f:
 			buf = f.read()
 	else:

--- a/bfm_seedminer_autolauncher.py
+++ b/bfm_seedminer_autolauncher.py
@@ -24,6 +24,7 @@ ctrc_kills_al_script = True
 active_job = False
 os_name = os.name
 skipUploadBecauseJobBroke = False
+count=0
 
 
 def signal_handler(sig, frame):
@@ -248,8 +249,9 @@ while True:
             time.sleep(30)
             continue
         if r.text == "nothing":
-            print("No work. Waiting 10 seconds...")
+            print("No work. Waited %d seconds..." % count, end='\r')
             time.sleep(10)
+            count+=10
         else:
             currentid = r.text
             skipUploadBecauseJobBroke = False
@@ -257,6 +259,7 @@ while True:
             if r2.text == "error":
                 print("Device already claimed, trying again...")
             else:
+                count=0
                 print("\nDownloading part1 for device " + currentid)
                 download_file(baseurl + '/getPart1?task=' +
                               currentid, 'movable_part1.sed')

--- a/bfm_seedminer_autolauncher.py
+++ b/bfm_seedminer_autolauncher.py
@@ -132,9 +132,9 @@ def getmax(lfcs):
 	print("Distance: %08X" % dist)
 	for i in distance:
 		if dist<i:
-			return max[c-1] + 10
+			return max[c-1]
 		c+=1
-	return max[len(distance)-1] + 10
+	return max[len(distance)-1]
 
 print("Checking for new release on GitHub...")
 githubReleaseRequest = s.get('https://api.github.com/repos/deadphoenix8091/bfm_autolauncher/releases/latest')

--- a/bfm_seedminer_autolauncher.py
+++ b/bfm_seedminer_autolauncher.py
@@ -17,9 +17,9 @@ import struct
 
 logging.basicConfig(level=logging.DEBUG, filename='bfm_autolauncher.log', filemode='w')
 s = requests.Session()
-baseurl = "https://bruteforcemovable.com"
+baseurl = "https://bfm.nintendohomebrew.com"
 currentid = ""
-currentVersion = "CURRENT_AUTOLAUNCHER_VERSION"
+currentVersion = "3.1.4"
 ctrc_kills_al_script = True
 active_job = False
 os_name = os.name
@@ -135,21 +135,6 @@ def getmax(lfcs):
 			return max[c-1]
 		c+=1
 	return max[len(distance)-1]
-
-print("Checking for new release on GitHub...")
-githubReleaseRequest = s.get('https://api.github.com/repos/deadphoenix8091/bfm_autolauncher/releases/latest')
-if githubReleaseRequest.status_code != 200:
-	print("ERROR: Unable to check GitHub for latest release.")
-	sys.exit(1)
-
-githubReleaseJson = githubReleaseRequest.json()
-if githubReleaseJson['tag_name'] != currentVersion :
-    print("Updating...")
-    download_file(githubReleaseJson['assets'][0]['browser_download_url'], 'bfm_seedminer_autolauncher.py')
-    subprocess.call([sys.executable, "bfm_seedminer_autolauncher.py"])
-    sys.exit(0)
-else:
-	print("Already up-to-date.")
 
 if os.path.isfile("bfm_autolauncher_exception.log"):
     try:


### PR DESCRIPTION
This change will stop the autolauncher from printing a new line for every "no work. waiting 10 seconds..." and instead update the total time waited on a single line. This cleans up stdout for those who like to review bfcl's output history.